### PR TITLE
Fix CI on deploying app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build with Astro
+      - name: Build app
         run: |
           pnpm run build --base "${{ steps.pages.outputs.base_path }}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,15 +27,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9
-        with:
-          cache: true
 
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Pages
         id: pages

--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
     "maplibre-gl": "^5.24.0",
     "tailwindcss": "^4.3.2"
   },
-  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba"
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882"
 }


### PR DESCRIPTION
An error occured when deploying the app:

```
Run pnpm/action-setup@v6.0.9
  
Running self-installer...
  added 1 package, and audited 2 packages in 2s
  1 package is looking for funding
    run `npm fund` for details
  1 high severity vulnerability
  To address all issues, run:
    npm audit fix --force
  Run `npm audit` for details.
  Checking for updates...
  Switching pnpm from v11.7.0 to v11.12.0...
  Error:  Cannot use 'in' operator to search for 'integrity' in undefined
  pnpm: Cannot use 'in' operator to search for 'integrity' in undefined
      at createFullPkgId (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:154891:19)
      at lockfileToDepGraph (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:154840:20)
      at hashDependencyPaths (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179640:17)
      at iteratePkgsForVirtualStore (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179594:44)
      at iteratePkgsForVirtualStore.next (<anonymous>)
      at buildGraphFromPackages (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179699:43)
      at lockfileToDepGraph2 (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179656:73)
      at headlessInstall (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:185801:288)
      at async installFromLockfile (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:238383:3)
      at async installPnpmToGlobalDir (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:238350:7)
Error: Something went wrong, self-installer exits with code 1

```

Solution is to downgrade pnpm version from `11.12` to `11.11`. No issue reported this bug at the time as writing, so I create on in action-setup repository: https://github.com/pnpm/action-setup/issues/276

Removed the cache config, because just in case.